### PR TITLE
Issue #110: Fix restore not correctly finding CMS type.

### DIFF
--- a/classes/customfield/cms_restore.php
+++ b/classes/customfield/cms_restore.php
@@ -56,7 +56,5 @@ trait cms_restore {
                 return $d->get('id');
             }
         }
-        // Should not get here.
-        throw new \moodle_exception("Bad shorname {$data['shortname']}, and type {$data['type']}");
     }
 }

--- a/tests/datasource_fields_test.php
+++ b/tests/datasource_fields_test.php
@@ -329,5 +329,8 @@ class datasource_fields_test extends \advanced_testcase {
         $newds = new dsfields($newcms);
 
         $this->assertEquals($ds->get_data(), $newds->get_data());
+
+        // Assert that the CMS type is not duplicated.
+        $this->assertEquals($cms->get('typeid'), $newcms->get('typeid'));
     }
 }

--- a/tests/datasource_images_test.php
+++ b/tests/datasource_images_test.php
@@ -183,5 +183,8 @@ class datasource_images_test extends \advanced_testcase {
         $newds = new dsimages($newcms);
 
         $this->assertEquals($ds->get_data(), $newds->get_data());
+
+        // Assert that the CMS type is not duplicated.
+        $this->assertEquals($cms->get('typeid'), $newcms->get('typeid'));
     }
 }

--- a/tests/datasource_roles_test.php
+++ b/tests/datasource_roles_test.php
@@ -311,5 +311,8 @@ class datasource_roles_test extends \advanced_testcase {
         $newds = new dsroles($newcms);
 
         $this->assertEquals($ds->get_data(), $newds->get_data());
+
+        // Assert that the CMS type is not duplicated.
+        $this->assertEquals($cms->get('typeid'), $newcms->get('typeid'));
     }
 }

--- a/tests/datasource_userlist_test.php
+++ b/tests/datasource_userlist_test.php
@@ -375,5 +375,8 @@ class datasource_userlist_test extends \advanced_testcase {
         $newds = new dsuserlist($newcms);
 
         $this->assertEquals($ds->get_data(), $newds->get_data());
+
+        // Assert that the CMS type is not duplicated.
+        $this->assertEquals($cms->get('typeid'), $newcms->get('typeid'));
     }
 }


### PR DESCRIPTION
Resovles #110.

Restore now correctly finds the matching CMS type for an instance.