### PR TITLE
Issue #116: Fix failure to update cache before accessing it.

### DIFF
--- a/classes/local/datasource/base.php
+++ b/classes/local/datasource/base.php
@@ -391,7 +391,10 @@ abstract class base {
         $key = $cmstype->get_custom_data(static::get_shortname() . 'confighash');
         // We expect there to be something, so false, null, '', and 0 are all illigit.
         if (empty($key)) {
-            throw new \moodle_exception('error:no_config_hash', 'mod_cms', '', $this->cms->get('id'));
+            debugging('Trying to gain a config cache key for ' . $this->cms->get('id') . ' without it being made.');
+            $this->update_config_cache_key();
+            $cmstype->read();
+            $key = $cmstype->get_custom_data(static::get_shortname() . 'confighash');
         }
         return $key;
     }

--- a/classes/local/datasource/traits/hashcache.php
+++ b/classes/local/datasource/traits/hashcache.php
@@ -62,7 +62,9 @@ trait hashcache {
             $key = $this->cms->get_custom_data(self::get_shortname() . 'instancehash');
             // We expect there to be something, so false, null, '', and 0 are all illigit.
             if (empty($key)) {
-                throw new \moodle_exception('error:no_instance_hash', 'mod_cms', '', $this->cms->get('id'));
+                debugging('Trying to gain an instance cache key for ' . $this->cms->get('id') . ' without it being made.');
+                $this->update_instance_cache_key();
+                $key = $this->cms->get_custom_data(self::get_shortname() . 'instancehash');
             }
         }
         return $key;

--- a/classes/local/datasource/traits/revcache.php
+++ b/classes/local/datasource/traits/revcache.php
@@ -49,7 +49,9 @@ trait revcache {
             $cacherev = $this->cms->get_custom_data($name);
             // We expect there to be something, so false, null, '', and 0 are all illigit.
             if (empty($cacherev)) {
-                throw new \moodle_exception('error:no_instance_hash', 'mod_cms', '', $this->cms->get('id'));
+                debugging('Trying to gain an instance cache key for ' . $this->cms->get('id') . ' without it being made.');
+                $this->update_instance_cache_key();
+                $cacherev = $this->cms->get_custom_data($name);
             }
         }
         // Combine with the ID to avoid clashes between instances.

--- a/classes/manage_content_types.php
+++ b/classes/manage_content_types.php
@@ -363,16 +363,17 @@ class manage_content_types {
      * @param \stdClass $data Form compatible data
      */
     public function update(int $id, \stdClass $data) {
-        $instance = $this->get_instance($id);
+        $cmstype = $this->get_instance($id);
         $cleandata = cms_types::clean_record($data);
-        $instance->from_record($cleandata);
-        $instance->update();
-        lib::reset_cms_names($id);
+        $cmstype->from_record($cleandata);
+        $cmstype->update();
 
         // Do post update actions for data sources.
-        foreach (dsbase::get_datasources($instance) as $ds) {
+        foreach (dsbase::get_datasources($cmstype) as $ds) {
             $ds->config_on_update($data);
         }
+
+        lib::reset_cms_names($id);
     }
 
     /**

--- a/tests/datasource_fields_test.php
+++ b/tests/datasource_fields_test.php
@@ -70,6 +70,7 @@ class datasource_fields_test extends \advanced_testcase {
         $cmstype = new cms_types();
         $cmstype->set('name', 'name');
         $cmstype->set('idnumber', 'test-name');
+        $cmstype->set('datasources', ['fields']);
         $cmstype->save();
 
         $cms = $cmstype->get_sample_cms();
@@ -79,8 +80,9 @@ class datasource_fields_test extends \advanced_testcase {
         $cms->save();
 
         $ds = new dsfields($cms);
-        $this->expectException('moodle_exception');
-        $ds->get_instance_cache_key();
+        // A cache key should be generated if one does not already exist.
+        $this->assertNotEmpty($ds->get_full_cache_key());
+        $this->assertDebuggingCalledCount(2);
     }
 
     /**

--- a/tests/datasource_images_test.php
+++ b/tests/datasource_images_test.php
@@ -66,6 +66,7 @@ class datasource_images_test extends \advanced_testcase {
         $cmstype = new cms_types();
         $cmstype->set('name', 'name');
         $cmstype->set('idnumber', 'test-name');
+        $cmstype->set('datasources', ['images']);
         $cmstype->save();
 
         $cms = $cmstype->get_sample_cms();
@@ -76,10 +77,12 @@ class datasource_images_test extends \advanced_testcase {
 
         $ds = new dsimages($cms);
         $this->assertEquals('', $ds->get_instance_cache_key());
-        $this->expectException('moodle_exception');
         $cmstype->set_custom_data('imagesconfighash', null);
         $cmstype->save();
         $ds->get_config_cache_key();
+        // A cache key should be generated if one does not already exist.
+        $this->assertNotEmpty($ds->get_full_cache_key());
+        $this->assertDebuggingCalled();
     }
 
     /**

--- a/tests/datasource_roles_test.php
+++ b/tests/datasource_roles_test.php
@@ -67,6 +67,7 @@ class datasource_roles_test extends \advanced_testcase {
         $cmstype = new cms_types();
         $cmstype->set('name', 'name');
         $cmstype->set('idnumber', 'test-name');
+        $cmstype->set('datasources', ['roles']);
         $cmstype->save();
 
         $cms = $cmstype->get_sample_cms();
@@ -76,8 +77,9 @@ class datasource_roles_test extends \advanced_testcase {
         $cms->save();
 
         $ds = new dsroles($cms);
-        $this->expectException('moodle_exception');
-        $ds->get_instance_cache_key();
+        // A cache key should be generated if one does not already exist.
+        $this->assertNotEmpty($ds->get_full_cache_key());
+        $this->assertDebuggingCalledCount(2);
     }
 
     /**

--- a/tests/datasource_userlist_test.php
+++ b/tests/datasource_userlist_test.php
@@ -63,6 +63,7 @@ class datasource_userlist_test extends \advanced_testcase {
         $cmstype = new cms_types();
         $cmstype->set('name', 'name');
         $cmstype->set('idnumber', 'test-name');
+        $cmstype->set('datasources', ['userlist']);
         $cmstype->save();
 
         $cms = $cmstype->get_sample_cms();
@@ -72,8 +73,9 @@ class datasource_userlist_test extends \advanced_testcase {
         $cms->save();
 
         $ds = new dsuserlist($cms);
-        $this->expectException('moodle_exception');
-        $ds->get_instance_cache_key();
+        // A cache key should be generated if one does not already exist.
+        $this->assertNotEmpty($ds->get_full_cache_key());
+        $this->assertDebuggingCalledCount(2);
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023112900;
+$plugin->version = 2023120100;
 $plugin->requires = 2020061500; // Moodle 3.9.0 and above.
 $plugin->supported = [39, 401]; // Moodle 3.9 to 4.1 inclusive.
 $plugin->component = 'mod_cms';


### PR DESCRIPTION
Resolves #116 

Move call to lib::reset_cms_names() to after calling config_on_update() in manage_content_types::update.
Change cache key retrieval to create a key if none exists. Previously would throw an exception
Update unit tests.