### PR TITLE
Fix phpunit issue from customfield_category with other plugin

### DIFF
--- a/tests/datasource_userlist_test.php
+++ b/tests/datasource_userlist_test.php
@@ -125,7 +125,7 @@ class datasource_userlist_test extends \advanced_testcase {
 
         $categoryrecord = $DB->get_records(
             'customfield_category',
-            ['itemid' => $itemid]
+            ['itemid' => $itemid, 'component' => 'mod_cms', 'area' => 'cmsuserlist']
         );
 
         $this->assertEquals(1, count($categoryrecord));


### PR DESCRIPTION
PHPUnit error occurs when testing with other plugin.

```
1) mod_cms\datasource_userlist_test::test_import
Failed asserting that 2 matches expected 1.

/var/www/mdl41-monash/mod/cms/tests/datasource_userlist_test.php:131
/var/www/mdl41-monash/mod/cms/tests/datasource_userlist_test.php:106
/var/www/mdl41-monash/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/mdl41-monash/vendor/phpunit/phpunit/phpunit:97
```

It looks there is another record from customfield_category.