### PR TITLE
Decode mod_cms content on restore

### DIFF
--- a/backup/moodle2/restore_cms_activity_task.class.php
+++ b/backup/moodle2/restore_cms_activity_task.class.php
@@ -61,6 +61,7 @@ class restore_cms_activity_task extends restore_activity_task {
 
         $contents[] = new restore_decode_content('cms', ['intro']);
         $contents[] = new restore_decode_content('cms_types', ['description']);
+        $contents[] = new restore_decode_content('customfield_data', 'value');
 
         return $contents;
     }

--- a/classes/local/datasource/restore/fields.php
+++ b/classes/local/datasource/restore/fields.php
@@ -65,7 +65,7 @@ class fields {
     /**
      * Code to be run after restoration.
      */
-    public function after_execute() {
+    public function after_restore() {
         $cmsid = $this->stepslib->get_new_parentid('cms');
         $cms = new cms($cmsid);
         $ds = new dsfields($cms);


### PR DESCRIPTION
Resolves two problems.

- Fixes customfield content not being decoded after restore. See also MDL-81913.
- Fixes a problem where the instance cache key was based on the pre-decoded content, resulting in multiple unique instances sharing the same cached value.

Note that instances with identical content may still share the same cached value.

```
php vendor/bin/phpunit --testsuite mod_cms_testsuite
Moodle 4.1.9+ (Build: 20240215), ded168b0066144a8223615de5088b3cc65a527fb
Php: 8.0.30, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.5.0-35-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

............................................................      60 / 60 (100%)

Time: 00:33.128, Memory: 129.00 MB

OK (60 tests, 253 assertions)
```