### PR TITLE
Add create instance to generator #122

### DIFF
--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -26,10 +26,26 @@ use core_customfield\field_controller;
  * @copyright 2024, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_cms_generator extends \component_generator_base {
+class mod_cms_generator extends testing_module_generator {
 
     /** @var int */
     protected $cmstypecount = 0;
+
+    /**
+     * Create new cms module instance
+     *
+     * @param array|stdClass $record
+     * @param array $options
+     * @return stdClass
+     */
+    public function create_instance($record = null, array $options = null) {
+        $record = (object) (array) $record;
+
+        // Simple setup to pass core_calendar\container_test::test_delete_module_delete_events.
+        $record->typeid = 0;
+
+        return parent::create_instance($record, (array) $options);
+    }
 
     /**
      * Get generator for custom fields.


### PR DESCRIPTION
Closes #122 

`\component_generator_base` was swapped to `testing_module_generator` to match generators in other mod classes and provide access to the parent create_instance() method.

Ideally typeid would be set up properly and match the other examples using something like create_cms_type(['datasources' => 'fields']), but this was causing cache key errors within test_delete_module_delete_events so I went with the minimal implementation to resolve the current issue.