### PR TITLE
Issue #66: Add template for search

### DIFF
--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -31,17 +31,7 @@ require_once($CFG->dirroot . '/mod/cms/lib.php');
  * @copyright  2024 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class cmsfield extends \core_search\base_activity {
-
-    /**
-     * @var array Internal quick static cache.
-     */
-    protected $cmsdata = [];
-
-    /**
-     * @var array Internal quick static cache.
-     */
-    protected $defaultvalues = null;
+class activity extends \core_search\base_activity {
 
     /**
      * Returns the document associated with this data id.
@@ -87,76 +77,6 @@ class cmsfield extends \core_search\base_activity {
         }
 
         return $doc;
-    }
-
-    /**
-     * Whether the user can access the document or not.
-     *
-     * @param int $id data id
-     * @return bool
-     */
-    public function check_access($id) {
-        try {
-            $data = $this->get_data($id);
-            $cminfo = $this->get_cm('cms', $data->id, $data->courseid);
-            $context = \context_module::instance($cminfo->id);
-        } catch (\dml_missing_record_exception $ex) {
-            return \core_search\manager::ACCESS_DELETED;
-        } catch (\dml_exception $ex) {
-            return \core_search\manager::ACCESS_DENIED;
-        }
-
-        // Recheck uservisible although it should have already been checked in core_search.
-        if ($cminfo->uservisible === false) {
-            return \core_search\manager::ACCESS_DENIED;
-        }
-
-        if (!has_capability('mod/cms:view', $context)) {
-            return \core_search\manager::ACCESS_DENIED;
-        }
-
-        return \core_search\manager::ACCESS_GRANTED;
-    }
-
-    /**
-     * Link to the cms.
-     *
-     * @param \core_search\document $doc
-     * @return \moodle_url
-     */
-    public function get_doc_url(\core_search\document $doc) {
-        $contextmodule = \context::instance_by_id($doc->get('contextid'));
-        $cm = get_coursemodule_from_id('cms', $contextmodule->instanceid, $doc->get('courseid'), true);
-        return new \moodle_url('/course/view.php', ['id' => $doc->get('courseid'), 'section' => $cm->sectionnum]);
-    }
-
-    /**
-     * Link to the cms.
-     *
-     * @param \core_search\document $doc
-     * @return \moodle_url
-     */
-    public function get_context_url(\core_search\document $doc) {
-        $contextmodule = \context::instance_by_id($doc->get('contextid'));
-        return new \moodle_url('/mod/cms/view.php', ['id' => $contextmodule->instanceid]);
-    }
-
-    /**
-     * Returns the specified data from its internal cache.
-     *
-     * @throws \dml_missing_record_exception
-     * @param int $id
-     * @return stdClass
-     */
-    protected function get_data($id) {
-        global $DB;
-        if (empty($this->cmsdata[$id])) {
-            $sql = "SELECT mc.id, mc.course AS courseid
-                      FROM {cms} mc
-                     WHERE mc.id = :id";
-            $this->cmsdata[$id] = $DB->get_record_sql($sql, ['id' => $id], MUST_EXIST);
-        }
-        return $this->cmsdata[$id];
     }
 
     /**

--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -21,8 +21,6 @@ defined('MOODLE_INTERNAL') || die();
 use mod_cms\local\model\cms;
 use mod_cms\local\renderer;
 
-require_once($CFG->dirroot . '/mod/cms/lib.php');
-
 /**
  * Define search area.
  *

--- a/classes/search/cmsfield.php
+++ b/classes/search/cmsfield.php
@@ -275,7 +275,7 @@ class cmsfield extends \core_search\base_mod {
     }
 
     /**
-     * Add the forum post attachments.
+     * Add the cms file attachments.
      *
      * @param document $document The current document
      * @return null

--- a/classes/search/cmsfield.php
+++ b/classes/search/cmsfield.php
@@ -72,7 +72,7 @@ class cmsfield extends \core_search\base_mod {
                          JOIN {customfield_category} mcc ON mcf.categoryid = mcc.id
                  $contextjoin
                         WHERE mcd.timemodified >= ? AND mcc.component = 'mod_cms' AND mcc.area = 'cmsfield'
-                          AND mcf.type IN ('textarea', 'text')
+                          AND mcf.type IN ('textarea', 'text', 'file')
                      GROUP BY mc.id
                        ) cdata ON ccms.id = cdata.id
                   JOIN {customfield_field} cmcf ON cmcf.id = cdata.fieldid
@@ -81,10 +81,11 @@ class cmsfield extends \core_search\base_mod {
                        null AS dataid, null AS value, null AS valueformat,
                        mc.timecreated timecreated, mc.timemodified timemodified
                  FROM {cms} mc
+         $contextjoin
             LEFT JOIN {customfield_data} mcd ON mc.id = mcd.instanceid
                 WHERE mcd.id IS NULL AND mc.timecreated >= ?
              ORDER BY timemodified ASC";
-        return $DB->get_recordset_sql($sql, array_merge($contextparams, [$modifiedfrom, $modifiedfrom]));
+        return $DB->get_recordset_sql($sql, array_merge($contextparams, [$modifiedfrom], $contextparams, [$modifiedfrom]));
     }
 
     /**
@@ -252,5 +253,61 @@ class cmsfield extends \core_search\base_mod {
             $this->cmsdata[$id] = $DB->get_record_sql($sql, ['id' => $id], MUST_EXIST);
         }
         return $this->cmsdata[$id];
+    }
+
+    /**
+     * Returns true if this area uses file indexing.
+     *
+     * @return bool
+     */
+    public function uses_file_indexing() {
+        return true;
+    }
+
+    /**
+     * Return the context info required to index files for
+     * this search area.
+     *
+     * @return array
+     */
+    public function get_search_fileareas() {
+        return ['value'];
+    }
+
+    /**
+     * Add the forum post attachments.
+     *
+     * @param document $document The current document
+     * @return null
+     */
+    public function attach_files($document) {
+        global $DB;
+
+        $fileareas = $this->get_search_fileareas();
+        // File is in "customfield_file" for component, "value" for filearea, and for customfield data id for itemid.
+        $contextid = \context_system::instance()->id;
+        $component = 'customfield_file';
+        $cmsid = $document->get('itemid');
+
+        // Search customfield data from cms record.
+        $sql = "SELECT mcd.id
+                  FROM {cms} mc
+                  JOIN {customfield_data} mcd ON mc.id = mcd.instanceid
+                  JOIN {customfield_field} mcf ON mcf.id = mcd.fieldid
+                  JOIN {customfield_category} mcc ON mcf.categoryid = mcc.id
+                 WHERE mc.id = ? AND mcc.component = 'mod_cms' AND mcc.area = 'cmsfield' AND mcf.type = 'file'";
+        $param = [$cmsid];
+        $filedata = $DB->get_records_sql($sql, $param);
+
+        foreach ($fileareas as $filearea) {
+            foreach ($filedata as $data) {
+                $fs = get_file_storage();
+                $files = $fs->get_area_files($contextid, $component, $filearea, $data->id, '', false);
+
+                foreach ($files as $file) {
+                    $document->add_stored_file($file);
+                }
+            }
+        }
     }
 }

--- a/classes/search/cmsfield.php
+++ b/classes/search/cmsfield.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/mod/cms/lib.php');
  * @copyright  2024 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class cmsfield extends \core_search\base_mod {
+class cmsfield extends \core_search\base_activity {
 
     /**
      * @var array Internal quick static cache.
@@ -44,53 +44,6 @@ class cmsfield extends \core_search\base_mod {
     protected $defaultvalues = null;
 
     /**
-     * Returns recordset containing required data for indexing cmsfield records.
-     *
-     * @param int $modifiedfrom timestamp
-     * @param \context|null $context Optional context to restrict scope of returned results
-     * @return \moodle_recordset|null Recordset (or null if no results)
-     */
-    public function get_document_recordset($modifiedfrom = 0, \context $context = null) {
-        global $DB;
-
-        list ($contextjoin, $contextparams) = $this->get_context_restriction_sql(
-                $context, 'cms', 'mc');
-        if ($contextjoin === null) {
-            return null;
-        }
-
-        // Search area is from customfield_data, but if the record is missing from activity, use default value.
-        $sqlgroupconcat = $DB->sql_group_concat("mcd.value", ', ', 'mcf.sortorder');
-        $sql = "SELECT ccms.id, ccms.course AS courseid, ccms.typeid, cmcf.name AS fieldname, cmcf.type,
-                       cdata.dataid dataid, cdata.value AS value, cdata.valueformat AS valueformat,
-                       cdata.timecreated AS timecreated, cdata.timemodified AS timemodified
-                  FROM {cms} ccms
-                  JOIN (
-                       SELECT mc.id, MAX(mcf.id) AS fieldid,
-                              MAX(mcd.id) dataid, {$sqlgroupconcat} AS value, MAX(mcd.valueformat) AS valueformat,
-                              MAX(mcd.timecreated) AS timecreated, MAX(mcd.timemodified) AS timemodified
-                         FROM {cms} mc
-                         JOIN {customfield_data} mcd ON mc.id = mcd.instanceid
-                         JOIN {customfield_field} mcf ON mcf.id = mcd.fieldid
-                         JOIN {customfield_category} mcc ON mcf.categoryid = mcc.id
-                 $contextjoin
-                        WHERE mcd.timemodified >= ? AND mcc.component = 'mod_cms' AND mcc.area = 'cmsfield'
-                          AND mcf.type IN ('textarea', 'text')
-                     GROUP BY mc.id
-                       ) cdata ON ccms.id = cdata.id
-                  JOIN {customfield_field} cmcf ON cmcf.id = cdata.fieldid
-                 UNION
-                SELECT mc.id, mc.course AS courseid, mc.typeid, null AS fieldname, null AS type,
-                       null AS dataid, null AS value, null AS valueformat,
-                       mc.timecreated timecreated, mc.timemodified timemodified
-                 FROM {cms} mc
-            LEFT JOIN {customfield_data} mcd ON mc.id = mcd.instanceid
-                WHERE mcd.id IS NULL AND mc.timecreated >= ?
-             ORDER BY timemodified ASC";
-        return $DB->get_recordset_sql($sql, array_merge($contextparams, [$modifiedfrom, $modifiedfrom]));
-    }
-
-    /**
      * Returns the document associated with this data id.
      *
      * @param stdClass $record
@@ -99,7 +52,7 @@ class cmsfield extends \core_search\base_mod {
      */
     public function get_document($record, $options = []) {
         try {
-            $cm = $this->get_cm('cms', $record->id, $record->courseid);
+            $cm = $this->get_cm('cms', $record->id, $record->course);
             $context = \context_module::instance($cm->id);
         } catch (\dml_missing_record_exception $ex) {
             // Notify it as we run here as admin, we should see everything.
@@ -112,53 +65,18 @@ class cmsfield extends \core_search\base_mod {
             return false;
         }
 
-        $defaultvalues = $this->get_default_values();
-
-        // Check if it's default value or not.
-        if (empty($record->dataid)) {
-            $title = $defaultvalues[$record->typeid]->fieldname ?? '';
-            $value = $defaultvalues[$record->typeid]->value ?? '';
-            if (isset($defaultvalues[$record->typeid]->valueformat)) {
-                $valueformat = $defaultvalues[$record->typeid]->valueformat;
-            } else {
-                if ($record->type == 'textarea') {
-                    $valueformat = FORMAT_HTML;
-                } else {
-                    $valueformat = FORMAT_PLAIN;
-                }
-            }
-        } else {
-            $title = $record->fieldname;
-            $value = $record->value;
-            $valueformat = $record->valueformat;
-        }
-
-        // Add mustache template to value.
-        if (!empty($defaultvalues[$record->typeid]->mustache)) {
-            $cms = new cms($cm->instance);
-            $renderer = new renderer($cms);
-            ob_start();
-            try {
-                // Indexer uses "Empty" session, it may get an error from rendering.
-                $value .= $renderer->get_html();
-            } catch (\Exception $e) {
-                // Use template when an error occurs.
-                $value .= ' ' . $defaultvalues[$record->typeid]->mustache;
-            }
-            // Do not show any errors from rendering.
-            ob_end_clean();
-            if (empty($title)) {
-                $title = $defaultvalues[$record->typeid]->name;
-            }
-            $valueformat = FORMAT_HTML;
-        }
+        $cms = new cms($cm->instance);
+        $renderer = new renderer($cms);
+        $value = $renderer->get_html();
+        $title = $cms->get('name');
+        $valueformat = FORMAT_HTML;
 
         // Prepare associative array with data from DB.
         $doc = \core_search\document_factory::instance($record->id, $this->componentname, $this->areaname);
         $doc->set('title', content_to_text($title, false));
         $doc->set('content', content_to_text($value, $valueformat));
         $doc->set('contextid', $context->id);
-        $doc->set('courseid', $record->courseid);
+        $doc->set('courseid', $record->course);
         $doc->set('owneruserid', \core_search\manager::NO_OWNER_ID);
         $doc->set('modified', $record->timemodified);
 
@@ -169,54 +87,6 @@ class cmsfield extends \core_search\base_mod {
         }
 
         return $doc;
-    }
-
-    /**
-     * Get default value for cms custom field.
-     *
-     * @return array
-     */
-    protected function get_default_values() {
-        global $DB;
-        if (is_null($this->defaultvalues)) {
-            $defaultvalues = [];
-            $sql = "SELECT mcf.id fieldid, mct.id typeid, mcf.configdata, mcf.name fieldname
-                      FROM {cms_types} mct
-                      JOIN {customfield_category} mcc ON mcc.itemid = mct.id
-                      JOIN {customfield_field} mcf ON mcf.categoryid = mcc.id
-                     WHERE mcc.component = 'mod_cms' AND mcc.area = 'cmsfield' AND mcf.type IN ('textarea', 'text')
-                  ORDER BY mct.id, mcf.sortorder";
-            $cmstypes = $DB->get_records_sql($sql);
-            foreach ($cmstypes as $cmstype) {
-                if (empty($defaultvalues[$cmstype->typeid])) {
-                    $data = new \stdClass();
-                    $configdata = json_decode($cmstype->configdata);
-                    $data->value = $configdata->defaultvalue ?? 'Default value';
-                    $data->valueformat = $configdata->defaultvalueformat ?? 0;
-                    $data->fieldname = $cmstype->fieldname;
-                } else {
-                    $data = $defaultvalues[$cmstype->typeid];
-                    $configdata = json_decode($cmstype->configdata);
-                    $data->value .= ', ' . $configdata->defaultvalue;
-                }
-                $defaultvalues[$cmstype->typeid] = $data;
-            }
-
-            // Add mustache template for default value.
-            $sql = "SELECT mct.id, mct.name, mct.mustache
-                      FROM {cms_types} mct";
-            $mustaches = $DB->get_records_sql($sql);
-            foreach ($mustaches as $mustache) {
-                if (empty($defaultvalues[$mustache->id])) {
-                    $defaultvalues[$mustache->id] = new \stdClass();
-                }
-                $defaultvalues[$mustache->id]->name = $mustache->name;
-                $defaultvalues[$mustache->id]->mustache = $mustache->mustache;
-            }
-
-            $this->defaultvalues = $defaultvalues;
-        }
-        return $this->defaultvalues;
     }
 
     /**

--- a/classes/search/cmsfield.php
+++ b/classes/search/cmsfield.php
@@ -130,6 +130,14 @@ class cmsfield extends \core_search\base_mod {
             $value = $record->value;
             $valueformat = $record->valueformat;
         }
+        // Add mustache template to value.
+        if (!empty($defaultvalues[$record->typeid]->mustache)) {
+            $value .= ' ' . $defaultvalues[$record->typeid]->mustache;
+            if (empty($title)) {
+                $title = $defaultvalues[$record->typeid]->name;
+            }
+            $valueformat = FORMAT_HTML;
+        }
 
         // Prepare associative array with data from DB.
         $doc = \core_search\document_factory::instance($record->id, $this->componentname, $this->areaname);
@@ -179,6 +187,19 @@ class cmsfield extends \core_search\base_mod {
                 }
                 $defaultvalues[$cmstype->typeid] = $data;
             }
+
+            // Add mustache template for default value.
+            $sql = "SELECT mct.id, mct.name, mct.mustache
+                      FROM {cms_types} mct";
+            $mustaches = $DB->get_records_sql($sql);
+            foreach ($mustaches as $mustache) {
+                if (empty($defaultvalues[$mustache->id])) {
+                    $defaultvalues[$mustache->id] = new \stdClass();
+                }
+                $defaultvalues[$mustache->id]->name = $mustache->name;
+                $defaultvalues[$mustache->id]->mustache = $mustache->mustache;
+            }
+
             $this->defaultvalues = $defaultvalues;
         }
         return $this->defaultvalues;

--- a/classes/search/cmsfield.php
+++ b/classes/search/cmsfield.php
@@ -18,6 +18,9 @@ namespace mod_cms\search;
 
 defined('MOODLE_INTERNAL') || die();
 
+use mod_cms\local\model\cms;
+use mod_cms\local\renderer;
+
 require_once($CFG->dirroot . '/mod/cms/lib.php');
 
 /**
@@ -95,7 +98,6 @@ class cmsfield extends \core_search\base_mod {
      * @return \core_search\document
      */
     public function get_document($record, $options = []) {
-        global $DB;
         try {
             $cm = $this->get_cm('cms', $record->id, $record->courseid);
             $context = \context_module::instance($cm->id);
@@ -130,9 +132,21 @@ class cmsfield extends \core_search\base_mod {
             $value = $record->value;
             $valueformat = $record->valueformat;
         }
+
         // Add mustache template to value.
         if (!empty($defaultvalues[$record->typeid]->mustache)) {
-            $value .= ' ' . $defaultvalues[$record->typeid]->mustache;
+            $cms = new cms($cm->instance);
+            $renderer = new renderer($cms);
+            ob_start();
+            try {
+                // Indexer uses "Empty" session, it may get an error from rendering.
+                $value .= $renderer->get_html();
+            } catch (\Exception $e) {
+                // Use template when an error occurs.
+                $value .= ' ' . $defaultvalues[$record->typeid]->mustache;
+            }
+            // Do not show any errors from rendering.
+            ob_end_clean();
             if (empty($title)) {
                 $title = $defaultvalues[$record->typeid]->name;
             }

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -104,7 +104,7 @@ $string['error:no_instance_hash'] = 'Module {$a} has no instance hash.';
 $string['error:no_config_hash'] = 'Module {$a} has no config hash.';
 
 // Search strings.
-$string['search:cmsfield'] = 'CMS';
+$string['search:activity'] = 'CMS - activity information';
 
 // Site datasource strings.
 $string['site:displayname'] = 'Site Info';

--- a/tests/search/search_test.php
+++ b/tests/search/search_test.php
@@ -26,7 +26,8 @@
 
 namespace mod_cms\search;
 
-use mod_cms\customfield\cmsfield_handler;
+use mod_cms\local\datasource\fields as dsfields;
+use mod_cms\local\model\cms;
 use mod_cms\local\model\cms_types;
 
 defined('MOODLE_INTERNAL') || die();
@@ -82,7 +83,8 @@ class search_test extends \advanced_testcase {
         $cmstype = new cms_types();
         $cmstype->set('name', 'Overview')
             ->set('idnumber', 'overview')
-            ->set('mustache', 'Template doc')
+            ->set('mustache', 'Template doc {{fields.overview}}')
+            ->set('datasources', ['fields'])
             ->set('title_mustache', 'Overview');
         $cmstype->save();
         $fieldcategory = self::getDataGenerator()->create_custom_field_category([
@@ -138,20 +140,25 @@ class search_test extends \advanced_testcase {
         $this->assertInstanceOf('\mod_cms\search\cmsfield', $searcharea);
 
         $course = self::getDataGenerator()->create_course();
+        $overviews = [];
 
         // The name of cms activity is from cms_type, so we do not set when creating the activity.
         $generator = self::getDataGenerator()->get_plugin_generator('mod_cms');
+        $overview1 = 'Test overview text 1';
         $record = new \stdClass();
         $record->course = $course->id;
-        $record->customfield_overview = 'Test overview text 1';
+        $record->customfield_overview = $overview1;
         $record->typeid = $this->cmstype->get('id');
         $cms1 = $generator->create_instance_with_data($record);
+        $overviews[$cms1->id] = $overview1;
 
+        $overview2 = 'Test overview text 2';
         $record = new \stdClass();
         $record->course = $course->id;
-        $record->customfield_overview = 'Test overview text 2';
+        $record->customfield_overview = $overview2;
         $record->typeid = $this->cmstype->get('id');
         $cms2 = $generator->create_instance_with_data($record);
+        $overviews[$cms2->id] = $overview2;
 
         // All records.
         $recordset = $searcharea->get_document_recordset();
@@ -168,19 +175,20 @@ class search_test extends \advanced_testcase {
         // Wait 1 sec to have new search string.
         sleep(1);
         $time = time();
+        $overview3 = 'Test overview text 3';
         $record = new \stdClass();
         $record->course = $course->id;
-        $record->customfield_overview = 'Test overview text 3';
+        $record->customfield_overview = $overview3;
         $record->typeid = $this->cmstype->get('id');
         $cms3 = $generator->create_instance_with_data($record);
         $context = \context_module::instance($cms3->cmid);
+        $overviews[$cms3->id] = $overview3;
 
         // Return only new search.
         $recordset = $searcharea->get_document_recordset($time);
         $count = 0;
         foreach ($recordset as $record) {
             $this->assertInstanceOf('stdClass', $record);
-            $data = $DB->get_record('customfield_data', ['id' => $record->dataid]);
             $doc = $searcharea->get_document($record);
             $this->assertInstanceOf('\core_search\document', $doc);
             $this->assertEquals('mod_cms-cmsfield-' . $record->id, $doc->get('id'));
@@ -188,17 +196,17 @@ class search_test extends \advanced_testcase {
             $this->assertEquals($course->id, $doc->get('courseid'));
             $this->assertEquals($context->id, $doc->get('contextid'));
             $this->assertEquals($this->field->get('name'), $doc->get('title'));
-            $this->assertStringContainsString($data->value, $doc->get('content'));
-            $this->assertStringContainsString($this->cmstype->get('mustache'), $doc->get('content'));
+            $this->assertStringContainsString($overviews[$doc->get('itemid')], $doc->get('content'));
             $count++;
         }
         $this->assertEquals(1, $count);
         $recordset->close();
 
         // Update existing data.
-        $cms1->customfield_overview = 'Update test 1';
-        $handler = cmsfield_handler::create($cms1->typeid);
-        $handler->instance_form_save($cms1);
+        $cms = new cms($cms1->id);
+        $ds = new dsfields($cms);
+        $ds->update_instance((object) ['id' => $cms1->id, 'customfield_overview' => 'Update test 1'], false);
+
         // Return 2 records.
         $recordset = $searcharea->get_document_recordset($time);
         $this->assertTrue($recordset->valid());
@@ -230,7 +238,6 @@ class search_test extends \advanced_testcase {
         $count = 0;
         foreach ($recordset as $record) {
             $this->assertInstanceOf('stdClass', $record);
-            $this->assertEmpty($record->dataid);
             $doc = $searcharea->get_document($record);
             $this->assertInstanceOf('\core_search\document', $doc);
             // Confirm the content is from defaultvalue from cms fieldtype.
@@ -241,9 +248,9 @@ class search_test extends \advanced_testcase {
         $recordset->close();
 
         // Add custom data for the cms activity.
-        $cms1->customfield_overview = 'Update test 1';
-        $handler = cmsfield_handler::create($cms1->typeid);
-        $handler->instance_form_save($cms1);
+        $cms = new cms($cms1->id);
+        $ds = new dsfields($cms);
+        $ds->update_instance((object) ['id' => $cms1->id, 'customfield_overview' => 'Update test 1'], false);
         $recordset = $searcharea->get_document_recordset();
         $count = 0;
         foreach ($recordset as $record) {
@@ -270,26 +277,45 @@ class search_test extends \advanced_testcase {
         $searcharea = \core_search\manager::get_search_area($this->cmsareaid);
         $this->assertInstanceOf('\mod_cms\search\cmsfield', $searcharea);
 
-        $course = self::getDataGenerator()->create_course();
-        $field = self::getDataGenerator()->create_custom_field([
+        $cmstype = new cms_types();
+        $cmstype->set('name', 'Multiple content')
+            ->set('idnumber', 'multiplecontent')
+            ->set('mustache', 'Overview: {{fields.overview}} Details: {{fields.details}}')
+            ->set('datasources', ['fields'])
+            ->set('title_mustache', 'Multiple content');
+        $cmstype->save();
+        $fieldcategory = self::getDataGenerator()->create_custom_field_category([
+            'name' => 'Multiple fields',
+            'component' => 'mod_cms',
+            'area' => 'cmsfield',
+            'itemid' => $cmstype->get('id'),
+        ]);
+        $field1 = self::getDataGenerator()->create_custom_field([
+            'name' => 'Overview',
+            'shortname' => 'overview',
+            'type' => 'text',
+            'categoryid' => $fieldcategory->get('id'),
+            'configdata' => json_encode(['defaultvalue' => 'Default Text Overview']),
+        ]);
+        $field2 = self::getDataGenerator()->create_custom_field([
             'name' => 'Details',
             'shortname' => 'details',
             'type' => 'text',
-            'categoryid' => $this->fieldcategory->get('id'),
+            'categoryid' => $fieldcategory->get('id'),
             'configdata' => json_encode(['defaultvalue' => 'Default Text Details']),
         ]);
+        $course = self::getDataGenerator()->create_course();
 
         $generator = self::getDataGenerator()->get_plugin_generator('mod_cms');
         $record = new \stdClass();
         $record->course = $course->id;
-        $record->typeid = $this->cmstype->get('id');
+        $record->typeid = $cmstype->get('id');
         $cms1 = $generator->create_instance_with_data($record);
 
         $recordset = $searcharea->get_document_recordset();
         $count = 0;
         foreach ($recordset as $record) {
             $this->assertInstanceOf('stdClass', $record);
-            $this->assertEmpty($record->dataid);
             $doc = $searcharea->get_document($record);
             $this->assertInstanceOf('\core_search\document', $doc);
             $this->assertStringContainsString('Default Text Overview', $doc->get('content'));
@@ -300,10 +326,13 @@ class search_test extends \advanced_testcase {
         $recordset->close();
 
         // Add data for the cms activity.
-        $cms1->customfield_overview = 'Overview test 1';
-        $cms1->customfield_details = 'Details test 1';
-        $handler = cmsfield_handler::create($cms1->typeid);
-        $handler->instance_form_save($cms1);
+        $cms = new cms($cms1->id);
+        $ds = new dsfields($cms);
+        $cmsfields = new \stdClass();
+        $cmsfields->id = $cms1->id;
+        $cmsfields->customfield_overview = 'Overview test 1';
+        $cmsfields->customfield_details = 'Details test 1';
+        $ds->update_instance($cmsfields, false);
         $recordset = $searcharea->get_document_recordset();
         $count = 0;
         foreach ($recordset as $record) {

--- a/tests/search/search_test.php
+++ b/tests/search/search_test.php
@@ -43,7 +43,7 @@ require_once($CFG->dirroot . '/search/tests/fixtures/testable_core_search.php');
  * @author      Tomo Tsuyuki <tomotsuyuki@catalyst-au.com>
  * @copyright   2024 Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @coversDefaultClass \mod_cms\search\cmsfield
+ * @coversDefaultClass \mod_cms\search\activity
  */
 class search_test extends \advanced_testcase {
 
@@ -74,7 +74,7 @@ class search_test extends \advanced_testcase {
         $this->resetAfterTest();
         set_config('enableglobalsearch', true);
 
-        $this->cmsareaid = \core_search\manager::generate_areaid('mod_cms', 'cmsfield');
+        $this->cmsareaid = \core_search\manager::generate_areaid('mod_cms', 'activity');
 
         // Set \core_search::instance to the mock_search_engine as we don't require the search engine to be working to test this.
         $search = \testable_core_search::instance();
@@ -137,7 +137,7 @@ class search_test extends \advanced_testcase {
 
         // Returns the instance as long as the area is supported.
         $searcharea = \core_search\manager::get_search_area($this->cmsareaid);
-        $this->assertInstanceOf('\mod_cms\search\cmsfield', $searcharea);
+        $this->assertInstanceOf('\mod_cms\search\activity', $searcharea);
 
         $course = self::getDataGenerator()->create_course();
         $overviews = [];
@@ -191,7 +191,7 @@ class search_test extends \advanced_testcase {
             $this->assertInstanceOf('stdClass', $record);
             $doc = $searcharea->get_document($record);
             $this->assertInstanceOf('\core_search\document', $doc);
-            $this->assertEquals('mod_cms-cmsfield-' . $record->id, $doc->get('id'));
+            $this->assertEquals('mod_cms-activity-' . $record->id, $doc->get('id'));
             $this->assertEquals($record->id, $doc->get('itemid'));
             $this->assertEquals($course->id, $doc->get('courseid'));
             $this->assertEquals($context->id, $doc->get('contextid'));
@@ -223,7 +223,7 @@ class search_test extends \advanced_testcase {
      */
     public function test_default_content(): void {
         $searcharea = \core_search\manager::get_search_area($this->cmsareaid);
-        $this->assertInstanceOf('\mod_cms\search\cmsfield', $searcharea);
+        $this->assertInstanceOf('\mod_cms\search\activity', $searcharea);
 
         $course = self::getDataGenerator()->create_course();
 
@@ -275,7 +275,7 @@ class search_test extends \advanced_testcase {
 
         // Returns the instance as long as the area is supported.
         $searcharea = \core_search\manager::get_search_area($this->cmsareaid);
-        $this->assertInstanceOf('\mod_cms\search\cmsfield', $searcharea);
+        $this->assertInstanceOf('\mod_cms\search\activity', $searcharea);
 
         $cmstype = new cms_types();
         $cmstype->set('name', 'Multiple content')

--- a/tests/search/search_test.php
+++ b/tests/search/search_test.php
@@ -190,12 +190,6 @@ class search_test extends \advanced_testcase {
             $this->assertEquals($this->field->get('name'), $doc->get('title'));
             $this->assertStringContainsString($data->value, $doc->get('content'));
             $this->assertStringContainsString($this->cmstype->get('mustache'), $doc->get('content'));
-
-            // Static caches are working.
-            $dbreads = $DB->perf_get_reads();
-            $doc = $searcharea->get_document($record);
-            $this->assertEquals($dbreads, $DB->perf_get_reads());
-            $this->assertInstanceOf('\core_search\document', $doc);
             $count++;
         }
         $this->assertEquals(1, $count);

--- a/tests/search/search_test.php
+++ b/tests/search/search_test.php
@@ -82,6 +82,7 @@ class search_test extends \advanced_testcase {
         $cmstype = new cms_types();
         $cmstype->set('name', 'Overview')
             ->set('idnumber', 'overview')
+            ->set('mustache', 'Template doc')
             ->set('title_mustache', 'Overview');
         $cmstype->save();
         $fieldcategory = self::getDataGenerator()->create_custom_field_category([
@@ -187,7 +188,8 @@ class search_test extends \advanced_testcase {
             $this->assertEquals($course->id, $doc->get('courseid'));
             $this->assertEquals($context->id, $doc->get('contextid'));
             $this->assertEquals($this->field->get('name'), $doc->get('title'));
-            $this->assertEquals($data->value, $doc->get('content'));
+            $this->assertStringContainsString($data->value, $doc->get('content'));
+            $this->assertStringContainsString($this->cmstype->get('mustache'), $doc->get('content'));
 
             // Static caches are working.
             $dbreads = $DB->perf_get_reads();
@@ -238,7 +240,7 @@ class search_test extends \advanced_testcase {
             $doc = $searcharea->get_document($record);
             $this->assertInstanceOf('\core_search\document', $doc);
             // Confirm the content is from defaultvalue from cms fieldtype.
-            $this->assertEquals('Default Text Overview', $doc->get('content'));
+            $this->assertStringContainsString('Default Text Overview', $doc->get('content'));
             $count++;
         }
         $this->assertEquals(1, $count);
@@ -253,7 +255,7 @@ class search_test extends \advanced_testcase {
         foreach ($recordset as $record) {
             $this->assertInstanceOf('stdClass', $record);
             $doc = $searcharea->get_document($record);
-            $this->assertEquals('Update test 1', $doc->get('content'));
+            $this->assertStringContainsString('Update test 1', $doc->get('content'));
             $count++;
         }
         $this->assertEquals(1, $count);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024090300;
+$plugin->version = 2024090301;
 $plugin->requires = 2022112800; // Moodle 4.1 and above.
 $plugin->supported = [401, 401]; // Moodle 4.1.
 $plugin->component = 'mod_cms';


### PR DESCRIPTION
Include a template area for searching.

**Testing instruction**

- Go to "Site administration" > "General" > "Advanced features".
- Enable Global search.
- Go to "Site administration" > "Plugins" > "Activity modules" > "CMS" > "Manage content types"
- Click "Add new content type".
- Set "Template test" in "Name", "test" in "ID Number", "Template test" in "Name" under "Activity fields", and "{{name}} Testsearchstring" in "Content" under "Activity field".
- Click "Save and display" and confirm the "Some name Testsearchstring" is in "Preview"
- Create a course.
- Turn on "Edit mode" and add "Template test" CMS activity.
- Go to "Site administration" > "Plugin" > "Search" > "Search areas".
- Click "Gradual reindex" for cms activity, and run "Global search indexing" schedule task.
- Search "Testsearchstring" in global search box.
- Confirm the "Testsearchstring" is in the result.