### PR TITLE
[Issue #121] Fix broken embedded file references

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -416,7 +416,7 @@ function xmldb_cms_upgrade($oldversion) {
     if ($oldversion < 2024090304) {
         // Update files belonging to mod_cms overview section content types to use the course module context id.
         // Update the pathnamehash as well, otherwise files will display as missing until the content is edited and saved.
-        // Records are effectively copied, the old records remain in case anything relies on them and they can be used to 
+        // Records are effectively copied, the old records remain in case anything relies on them and they can be used to
         // cross reference the new records if needed.
 
         $sql = "SELECT f.*, ctx.id as ctxid

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -413,5 +413,49 @@ function xmldb_cms_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2024090303, 'cms');
     }
 
+    if ($oldversion < 2024090304) {
+        // Update files belonging to mod_cms overview section content types to use the course module context id.
+        // Update the pathnamehash as well, otherwise files will display as missing until the content is edited and saved.
+        // Records are effectively copied, the old records remain in case anything relies on them and they can be used to 
+        // cross reference the new records if needed.
+
+        $sql = "SELECT f.*, ctx.id as ctxid
+                  FROM {files} f
+                  JOIN {customfield_data} cfd ON cfd.id = f.itemid
+                  JOIN {customfield_field} cff ON cff.id = cfd.fieldid AND cff.shortname = 'overview'
+                  JOIN {cms} cms ON cms.id = cfd.instanceid
+                  JOIN {course_modules} cm ON cm.instance = cms.id
+                  JOIN {modules} m ON m.id = cm.module AND m.name = 'cms'
+                  JOIN {context} ctx ON ctx.instanceid = cm.id AND ctx.contextlevel = 70
+                 WHERE f.contextid = 1 AND f.component = 'customfield_textarea' AND f.filearea = 'value'";
+
+        $records = $DB->get_recordset_sql($sql);
+        foreach ($records as $record) {
+            // Update the record with the new context id and path name hash.
+            $record->contextid = $record->ctxid;
+            $record->pathnamehash = file_storage::get_pathname_hash(
+                $record->contextid,
+                $record->component,
+                $record->filearea,
+                $record->itemid,
+                $record->filepath,
+                $record->filename
+            );
+
+            // Remove the record id and ctxid fields.
+            unset($record->ctxid);
+            unset($record->id);
+
+            // Create a new record.
+            try {
+                $DB->insert_record('files', $record);
+            } catch (moodle_exception $e) {
+                debugging('Failed to insert record into files table: ' . $e->getMessage(), DEBUG_DEVELOPER);
+            }
+        }
+
+        upgrade_mod_savepoint(true, 2024090304, 'cms');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -422,8 +422,9 @@ function xmldb_cms_upgrade($oldversion) {
         $sql = "SELECT f.*, ctx.id as ctxid
                   FROM {files} f
                   JOIN {customfield_data} cfd ON cfd.id = f.itemid
-                  JOIN {customfield_field} cff ON cff.id = cfd.fieldid AND cff.shortname = 'overview'
+                  JOIN {customfield_field} cff ON cff.id = cfd.fieldid
                   JOIN {cms} cms ON cms.id = cfd.instanceid
+                  JOIN {cms_types} cmst ON cmst.id = cms.typeid AND cmst.datasources LIKE '%fields%'
                   JOIN {course_modules} cm ON cm.instance = cms.id
                   JOIN {modules} m ON m.id = cm.module AND m.name = 'cms'
                   JOIN {context} ctx ON ctx.instanceid = cm.id AND ctx.contextlevel = :modulecontextlevel

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -426,10 +426,11 @@ function xmldb_cms_upgrade($oldversion) {
                   JOIN {cms} cms ON cms.id = cfd.instanceid
                   JOIN {course_modules} cm ON cm.instance = cms.id
                   JOIN {modules} m ON m.id = cm.module AND m.name = 'cms'
-                  JOIN {context} ctx ON ctx.instanceid = cm.id AND ctx.contextlevel = 70
+                  JOIN {context} ctx ON ctx.instanceid = cm.id AND ctx.contextlevel = :modulecontextlevel
                  WHERE f.contextid = 1 AND f.component = 'customfield_textarea' AND f.filearea = 'value'";
+        $params = ['modulecontextlevel' => CONTEXT_MODULE];
 
-        $records = $DB->get_recordset_sql($sql);
+        $records = $DB->get_recordset_sql($sql, $params);
         foreach ($records as $record) {
             // Update the record with the new context id and path name hash.
             $record->contextid = $record->ctxid;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024090303;
+$plugin->version = 2024090304;
 $plugin->requires = 2022112800; // Moodle 4.1 and above.
 $plugin->supported = [401, 401]; // Moodle 4.1.
 $plugin->component = 'mod_cms';


### PR DESCRIPTION
## Summary
This pull request addresses the issue of broken links for `customfield_textarea` embedded files with a context ID of 1, which happens as part of [pull request #131](https://github.com/catalyst/moodle-mod_cms/pull/131) and [issue #121](https://github.com/catalyst/moodle-mod_cms/issues/121). The problem arises because text areas will now assume that any files are located in the course module context. This pull request updates the file table to resolve this issue.

## Approach
New records are inserted with the course module context and updated `filepathhash` rather than updating the old file records. This approach has a few advantages:

1. **Backward Compatibility**: Existing files fetched by system context will (should) continue to work.
2. **Cross-Referencing**: New records can be cross-referenced with existing records.
3. **Future Cleanup**: Old records can be cleaned up at a later date without affecting current functionality.

## Testing Instructions
Testing this change is not straightforward but can be done by following these steps:


1. Checkout the [MOODLE_401_STABLE](https://github.com/catalyst/moodle-mod_cms/tree/MOODLE_401_STABLE) branch. 
2. Revert [pull request #119](https://github.com/catalyst/moodle-mod_cms/pull/119).
3. Edit an overview section and add some embedded files, such as images.
4. Verify that these files use context ID 1.
5. Unrevert [pull request #119](https://github.com/catalyst/moodle-mod_cms/pull/119).
6. Checkout [pull request #131](https://github.com/catalyst/moodle-mod_cms/pull/131).
7. Verify that the links are broken for the overview section.
8. Checkout this branch and update your Moodle installation.
9. Verify that the same overview section files now display correctly and can be backed up and restored without issue.

## Related Issues
- [Issue #121](https://github.com/catalyst/moodle-mod_cms/issues/121)
- [Pull Request #131](https://github.com/catalyst/moodle-mod_cms/pull/131)

## Additional Notes
I recommend backing up your database before applying these changes.
This should probably apply to more than just "overview" sections. What do you think?