### PR TITLE
Fix Adhoc task failed: mod_cms\task\update_files_context,Class 'csv_export_writer' not found

### DIFF
--- a/classes/task/update_files_context.php
+++ b/classes/task/update_files_context.php
@@ -61,7 +61,9 @@ class update_files_context extends adhoc_task {
      * @return csv_export_writer The CSV export writer containing the results of the task.
      */
     private static function update_contexts(?int $courseid, bool $dryrun): csv_export_writer {
-        global $DB;
+        global $CFG, $DB;
+
+        require_once($CFG->libdir . '/csvlib.class.php');
 
         $sql = "SELECT f.*, ctx.id AS ctxid, cms.course AS courseid
                   FROM {files} f

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -413,12 +413,12 @@ function xmldb_cms_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2024090303, 'cms');
     }
 
-    if ($oldversion < 2024090304) {
+    if ($oldversion < 2024090305) {
         // Run ad hoc task for updating contextid in the files table.
         $task = \mod_cms\task\update_files_context::instance(null, false);
         manager::queue_adhoc_task($task);
 
-        upgrade_mod_savepoint(true, 2024090304, 'cms');
+        upgrade_mod_savepoint(true, 2024090305, 'cms');
     }
 
     return true;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024090304;
+$plugin->version = 2024090305;
 $plugin->requires = 2020061500; // Moodle 3.9.0 and above.
 $plugin->supported = [39, 401]; // Moodle 3.9 to 4.1 inclusive.
 $plugin->component = 'mod_cms';


### PR DESCRIPTION
### TL;DR
The task works when executed but fails when scheduled:

```
Backtrace:
* line 53 of /mod/cms/classes/task/update_files_context.php: call to mod_cms\task\update_files_context::update_contexts()
* line 413 of /lib/cronlib.php: call to mod_cms\task\update_files_context->execute()
* line 206 of /lib/cronlib.php: call to cron_run_inner_adhoc_task()
* line 175 of /admin/cli/adhoc_task.php: call to cron_run_adhoc_tasks()
```

This fix allows the scheduled task to run.

### Testing
Upgrade the plugin.
Execute the pending ad hoc task.
Verify it completes.