### PR TITLE
Add Moodle 4.5 support

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace mod_cms;
+
+/**
+ * Hook callbacks for tool_redirects.
+ *
+ * @package     mod_cms
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2024 Catalyst IT Australia
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class hook_callbacks {
+
+    /**
+     * Listener for the after_config hook.
+     *
+     * @param \core\hook\after_config $hook
+     */
+    public static function after_config(\core\hook\after_config $hook): void {
+        // The original callback performs no operations, so we don't need to do anything here.
+    }
+}

--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -32,6 +32,8 @@ class hook_callbacks {
      * @param \core\hook\after_config $hook
      */
     public static function after_config(\core\hook\after_config $hook): void {
-        // The original callback performs no operations, so we don't need to do anything here.
+        global $CFG;
+
+        require_once($CFG->dirroot . '/vendor/autoload.php');
     }
 }

--- a/classes/local/datasource/restore/fields.php
+++ b/classes/local/datasource/restore/fields.php
@@ -32,6 +32,9 @@ class fields {
     /** @var \restore_cms_activity_structure_step The stepslib controlling this process. */
     protected $stepslib;
 
+    /** @var array Components array */
+    protected $components = [];
+
     /**
      * Constructs the processor.
      *

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -15,21 +15,19 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version information for the cms plugin.
+ * Hook callbacks.
  *
  * @package     mod_cms
- * @author      Marcus Boon<marcus@catalyst-au.net>
- * @copyright   Catalyst IT
- * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2024 Catalyst IT Australia
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024090306;
-$plugin->requires = 2022112800; // Moodle 4.1 and above.
-$plugin->supported = [401, 405]; // Moodle 4.1.
-$plugin->component = 'mod_cms';
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = 2023051800;
-
-$plugin->dependencies = [];
+$callbacks = [
+    [
+        'hook' => \core\hook\after_config::class,
+        'callback' => '\mod_cms\hook_callbacks::after_config',
+    ],
+];

--- a/tests/datasource_site_test.php
+++ b/tests/datasource_site_test.php
@@ -62,9 +62,10 @@ class datasource_site_test extends \advanced_testcase {
         $ds = new dssite($cms);
         $data = $ds->get_data();
 
-        $this->assertObjectHasAttribute('fullname', $data);
-        $this->assertObjectHasAttribute('shortname', $data);
-        $this->assertObjectHasAttribute('wwwroot', $data);
+        // Some versions of PHPUnit do not have assertObjectHasProperty(), and assertObjectHasAttribute() is deprecated.
+        $this->assertTrue(property_exists($data, 'fullname'));
+        $this->assertTrue(property_exists($data, 'shortname'));
+        $this->assertTrue(property_exists($data, 'wwwroot'));
     }
 
     /**

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -67,7 +67,7 @@ class renderer_test extends \advanced_testcase {
         foreach (dsbase::BUILTIN_DATASOURCES as $ds) {
             $classname = 'mod_cms\\local\\datasource\\' . $ds;
             $attribute = $classname::get_shortname();
-            $this->assertObjectHasAttribute($attribute, $data);
+            $this->assertTrue(property_exists($data, $attribute));
             $this->assertIsObject($data->$attribute);
         }
     }


### PR DESCRIPTION
Adds `after_config` hook and fixes some deprecated assert calls.