### PR TITLE
declare property for php 8.3

### DIFF
--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -32,6 +32,9 @@ class mod_cms_generator extends testing_module_generator {
     /** @var int */
     protected $cmstypecount = 0;
 
+    /** @var array $userlistcategories */
+    private $userlistcategories;
+
     /**
      * Create new cms module instance
      *


### PR DESCRIPTION
Only refrence to `userlistcategories`  is in `create_datasource_userlist_field` where its used as a way to cache the categories